### PR TITLE
Fix bug with fetching playtime leaderboard

### DIFF
--- a/src/models/guilds/leaderboards.py
+++ b/src/models/guilds/leaderboards.py
@@ -20,7 +20,7 @@ class LeaderboardModel(BaseModel):
 
     @classmethod
     async def fetch_playtime(cls, db: Database, month_start: date, guild_id: int) -> "LeaderboardModel":
-        month_end = datetime(year=month_start.year, month=month_start.month + 1, day=1)
+        month_end = datetime(year=month_start.year, month=month_start.month % 12 + 1, day=1)
         data = await db.pool.fetchrow("""
                     with t as (
                     select extract(epoch from sum(playtime)) as playtime, sv.thorny_id, u.user_id from events.sessions_view sv 


### PR DESCRIPTION
In december, it would try to get the end month as 13, when it is in fact 1